### PR TITLE
Fix bindfs defunct, and isolate bindfs-state

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,18 +1,25 @@
 FROM golang:1.9-stretch as builder
-COPY . /go/src/github.com/studioetrange/docker-volume-bindfs
-WORKDIR /go/src/github.com/studioetrange/docker-volume-bindfs
-RUN set -ex && go install --ldflags '-extldflags "-static"'
+COPY . /go/src/github.com/StudioEtrange/docker-volume-bindfs
+WORKDIR /go/src/github.com/StudioEtrange/docker-volume-bindfs
+ARG PLUGIN_TAG
+RUN set -ex && go install --ldflags '-extldflags "-static"' --ldflags "-X github.com/StudioEtrange/docker-volume-bindfs/version.Version=$PLUGIN_TAG"
 CMD ["/go/bin/docker-volume-bindfs"]
 
+
 FROM debian:jessie
-RUN apt-get update && apt-get install sudo curl git libfuse-dev -y
+RUN apt-get update && apt-get install sudo wget git libfuse-dev -y
 RUN mkdir -p /run/docker/plugins /mnt/state /mnt/volumes /mnt/host/ /work
 # install bindfs
 ARG BINDFS_VERSION
+
+
+RUN wget -O /dumb-init https://github.com/Yelp/dumb-init/releases/download/v1.2.2/dumb-init_1.2.2_amd64 \
+     && chmod +x /dumb-init
+
 RUN cd /work \
     && git clone https://github.com/StudioEtrange/stella \
     && cd /work/stella \
-    && git checkout bbf9dd926fd8025fc9aacf91bfbeae543e4b228f \
+    && git checkout 7848969cb84131beaa5d8026baada5aecf878555 \
     && /work/stella/stella.sh sys install build-chain-standard \
     && /work/stella/stella.sh feature install bindfs#${BINDFS_VERSION} \
     && export BINDFS_PATH=$(STELLA_LOG_STATE=OFF /work/stella/stella.sh boot cmd local -- '$STELLA_API feature_info "bindfs" "BINDFS" && echo $BINDFS_FEAT_INSTALL_ROOT') \

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 PLUGIN_NAME = studioetrange/bindfs
 PLUGIN_TAG ?= latest
-BINDFS_VERSION ?=1_13_10
+BINDFS_VERSION ?=1_13_11
 DOCKER_LOGIN ?=
 DOCKER_PASSWORD ?=
 
@@ -12,7 +12,7 @@ clean:
 
 rootfs:
 	@echo "### docker build: rootfs image with docker-volume-bindfs"
-	@docker build --no-cache --build-arg BINDFS_VERSION=${BINDFS_VERSION} -t ${PLUGIN_NAME}:rootfs .
+	@docker build --no-cache --build-arg BINDFS_VERSION=${BINDFS_VERSION} --build-arg PLUGIN_TAG=${PLUGIN_TAG} -t ${PLUGIN_NAME}:rootfs .
 	@echo "### create rootfs directory in ./plugin/rootfs"
 	@mkdir -p ./plugin/rootfs
 	@docker create --name tmp ${PLUGIN_NAME}:rootfs

--- a/README.md
+++ b/README.md
@@ -4,64 +4,64 @@
 This project is based on vieux/docker-volume-sshfs.
 With this plugin you're able to mount a given path and remap its owner and group.
 
-I recommend using this plugin with dev-environments **only**, cause of potential security issues.
+This is a fork of https://github.com/lebokus/docker-volume-bindfs
 
 ## About this fork
 
 * support multiple volume with same mount points
-* can choose version of bindfs (consult available version from https://github.com/StudioEtrange/stella/blob/master/nix/pool/feature-recipe/feature_bindfs.sh)
+* can choose version of bindfs (consult available version from [here](https://github.com/StudioEtrange/stella/blob/0c4d940b255faca281f0f40b24605c0ae23c0d4c/nix/pool/feature-recipe/feature_bindfs.sh)
 * add more info and clean build process
-* change plugin namespace
+* resolve bindfs defunct process each time a volume is destroyed
+* isolate bindfs-state.json state file for each plugin version
 
 ## Usage
 
-1 - Install the plugin
+### Install the plugin
+
+This will install the plugin from pre-built versions
 
 ```
-$ docker plugin install studioetrange/bindfs
-
-# or to enable debug
-docker plugin install studioetrange/bindfs DEBUG=1
-
+docker plugin install studioetrange/bindfs:1.1
 ```
 
-2 - Create a volume
+Optional debug option while install
+```
+docker plugin install studioetrange/bindfs:1.1 DEBUG=1
+```
+
+## Notes on available pre-built versions
+
+In docker hub, under [studioetrange/bindfs](https://hub.docker.com/r/studioetrange/bindfs) available versions are
+
+|PLUGIN NAME|BINDFS VERSION|NOTES|
+|---|---|---|
+|studioetrange/bindfs:1.1|1.13.11|recommended|
+|studioetrange/bindfs:1.0|1.13.10|*DO NOT USE* : Have a bug, create bindfs defunct process when removing volume|
+
+
+### Create a volume
 
 ```
-$ docker volume create -d studioetrange/bindfs -o sourcePath=$PWD -o map=$(id -u)/0:@$(id -g)/@0 [-o <any_bindfs_-o_option> ] bindfsvolume
+docker volume create -d studioetrange/bindfs:1.1 -o sourcePath=$PWD -o map=$(id -u)/0:@$(id -g)/@0 [-o <any_bindfs_-o_option> ] bindfsvolume
 
-$ docker volume ls
+docker volume ls
+
 DRIVER              VOLUME NAME
 local               be9632386a2d396d438c9707e261f86fd9f5e72a7319417901d84041c8f14a4d
 local               e1496dfe4fa27b39121e4383d1b16a0a7510f0de89f05b336aab3c0deb4dda0e
 studioetrange/bindfs      bindfsvolume
 ```
 
-3 - Use the volume
+### Use the volume
 
 ```
-$ docker run -it -v bindfsvolume:<path> busybox ls -la <path>
+docker run -it -v bindfsvolume:<path> busybox ls -la <path>
 ```
 
-## build plugin
 
-```
-git clone https://github.com/StudioEtrange/docker-volume-bindfs
-cd docker-volume-bindfs
-make
-```
 
-You can fix a TAG for plugin version and choose a bindfs version with
-```
-make PLUGIN_TAG=1.0 BINDFS_VERSION=1_13_10
-```
+## Example for docker-compose file
 
-## publish plugin
-```
-make DOCKER_LOGIN=foo DOCKER_PASSWORD=bar PLUGIN_TAG=1.0 push
-```
-
-## docker-compose example
 ```
 export EUID=$(id -u)
 export EGID=$(id -g)
@@ -78,11 +78,57 @@ services:
 
 volumes:
     data:
-        driver: studioetrange/bindfs:latest
+        driver: studioetrange/bindfs:1.1
         driver_opts:
             sourcePath: "${PWD}"
             map: "${EUID}/0:@${EGID}/@0"
 ```
+
+
+## Plugin development
+
+### Build plugin
+
+
+This will build plugin, tagged as latest, delete plugin if he already exists and install it
+
+```
+git clone https://github.com/StudioEtrange/docker-volume-bindfs
+cd docker-volume-bindfs
+make
+```
+
+Options : you can fix a TAG for the plugin version and choose a bindfs version
+
+```
+make PLUGIN_TAG=1.1 BINDFS_VERSION=1_13_11
+```
+
+
+### Enable built plugin
+
+This will enable the plugin, you need this before using it
+
+```
+make enable
+```
+
+Option :
+
+```
+make enable PLUGIN_TAG=1.1
+```
+
+
+
+### Publish plugin
+
+Publis a built plugin to docker hub
+
+```
+make DOCKER_LOGIN=foo DOCKER_PASSWORD=bar PLUGIN_TAG=1.1 push
+```
+
 
 ## LICENSE
 

--- a/config.json
+++ b/config.json
@@ -2,6 +2,7 @@
   "description": "bindFS plugin for Docker",
   "documentation": "https://docs.docker.com/engine/extend/plugins/",
   "entrypoint": [
+    "/dumb-init",
     "/docker-volume-bindfs"
   ],
   "env": [

--- a/main.go
+++ b/main.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/Sirupsen/logrus"
 	"github.com/docker/go-plugins-helpers/volume"
+	reaper "github.com/ramr/go-reaper"
 )
 
 const socketAddress = "/run/docker/plugins/bindfs.sock"
@@ -35,6 +36,8 @@ type bindfsDriver struct {
 
 func newBindfsDriver(root string) (*bindfsDriver, error) {
 	logrus.WithField("method", "new driver").Debug(root)
+
+	go reaper.Reap()
 
 	d := &bindfsDriver{
 		root:      filepath.Join(root, "volumes"),

--- a/main.go
+++ b/main.go
@@ -14,7 +14,7 @@ import (
 
 	"github.com/Sirupsen/logrus"
 	"github.com/docker/go-plugins-helpers/volume"
-	reaper "github.com/ramr/go-reaper"
+	version_pkg "github.com/StudioEtrange/docker-volume-bindfs/version"
 )
 
 const socketAddress = "/run/docker/plugins/bindfs.sock"
@@ -37,11 +37,9 @@ type bindfsDriver struct {
 func newBindfsDriver(root string) (*bindfsDriver, error) {
 	logrus.WithField("method", "new driver").Debug(root)
 
-	go reaper.Reap()
-
 	d := &bindfsDriver{
 		root:      filepath.Join(root, "volumes"),
-		statePath: filepath.Join(root, "state", "bindfs-state.json"),
+		statePath: filepath.Join(root, "state", "bindfs-state-" + version_pkg.Version + ".json"),
 		volumes:   map[string]*bindfsVolume{},
 	}
 

--- a/testdown.sh
+++ b/testdown.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+dds env destroy -y b1
+dds env destroy -y b2
+dds env destroy -y b3
+dds env destroy -y b4
+dds env list

--- a/testrmplugin.sh
+++ b/testrmplugin.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+sudo docker plugin ls
+sudo docker plugin disable studioetrange/bindfs:1.1
+sudo docker plugin rm studioetrange/bindfs:1.1
+sudo docker plugin ls

--- a/testup.sh
+++ b/testup.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+dds env launch b1 dds-centos-minimal:1.0 -d -v $HOME/tet:/work
+dds env launch b2 dds-centos-minimal:1.0 -d -v $HOME/toi:/work
+dds env launch b3 dds-centos-minimal:1.0 -d -v $HOME/tui:/work
+dds env launch b4 dds-centos-minimal:1.0 -d -v $HOME/tui:/work
+dds env list

--- a/version/version.go
+++ b/version/version.go
@@ -1,0 +1,6 @@
+package version
+
+// Version numbers set during build.
+var (
+	Version    = ""
+)


### PR DESCRIPTION
* isolate bindfs-state file for each plugin version,
* use dumb-init as pid1 into docker plugin
* upgrade bindfs default version to 1.13.11
* update README
