### PR TITLE
Fix removeVolume error message and add quick build snippet to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,13 @@ volumes:
 
 ### Build plugin
 
+* Quick build commands:
+
+    ```bash
+    git clone https://github.com/StudioEtrange/docker-volume-bindfs
+    cd docker-volume-bindfs
+    make all
+    ```
 
 * This will build plugin, tagged as latest, delete plugin if he already exists and install it
 

--- a/main.go
+++ b/main.go
@@ -297,7 +297,7 @@ func (d *bindfsDriver) removeVolume(v *bindfsVolume) error {
 		// Else remove everything in that mountpoint
 		if err := os.Remove(v.Mountpoint); err != nil {
 			// If the mount is not mounted, remove legacy
-			msg := fmt.Sprintf("Failed to remove the volume with sourcePath mountpoint %s (%s)", v.Sourcepath, v.Mountpoint, err)
+			msg := fmt.Sprintf("Failed to remove the volume with sourcePath %s at mountpoint %s (%v)", v.Sourcepath, v.Mountpoint, err)
 			log.Error(msg)
 			return fmt.Errorf(msg)
 		}


### PR DESCRIPTION
### Motivation
- Fix incorrect error formatting in `removeVolume` to correctly include the error value and clarify messaging, and provide a short quick-start build example in `README.md`.

### Description
- Update `main.go` to change the error message in `removeVolume` to use a clearer format that includes the source path, mountpoint and the error (`%v`), and add a "Quick build commands" section to `README.md` with `git clone` and `make all` examples.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dfeda46bc4832a9cbccc009b5b03ef)