### PR TITLE
Allow using disks mounted after Docker starts

### DIFF
--- a/config.json
+++ b/config.json
@@ -46,7 +46,8 @@
     {
       "destination": "/mnt/host",
       "options": [
-        "rbind"
+        "rbind",
+        "rslave"
       ],
       "name": "host-root",
       "source": "/",


### PR DESCRIPTION
This PR fixes an issue when starting containers which have studioetrange/bindfs volumes that point to mount points which were mounted on the host after Docker started. You get the following error:

> Error response from daemon: error while mounting volume '': VolumeDriver.Mount: Failed to mount volume-name, bindfs command failed /bin/bindfs /mnt/host/media/device/path/to/mount /mnt/volumes/6448cb22fe561a371dc3e01dc423e52aede277370a3dbb32429ceafdec94f821 -o [SNIP] exit status 1 (Failed to resolve source directory `/mnt/host/media/device/path/to/mount': No such file or directory)

The `rbind` option alone uses the default propagation of the source, which on most Linux systems is `private`, this means that the plugin only gets to see a snapshot of the mounted disks when it starts, not anything new. Using `slave` mode means that the plugin can see new mounts as they become available.

---

Full repro:

1. DiskA is mounted to the host
2. Docker starts
3. Docker volume VolA is created and points to DiskA
4. ContainerA is created which uses VolA
5. ContainerA is started and runs fine
6. System is rebooted (DiskA does not auto-mount)
7. Docker starts
8. DiskA is mounted
9. Container will not start

The issue is avoided if steps 7 and 8 are swapped, or Docker is restarted after step 8.